### PR TITLE
Social Login updates auth state and handles signout

### DIFF
--- a/src/AppContainer.js
+++ b/src/AppContainer.js
@@ -12,10 +12,6 @@ const mapStateToProps = (state) => {
 };
 
 class App extends Component {
-  componentDidMount() {
-    console.log(this.props);
-  }
-
   render() {
     return this.props.isLoggedIn ? <PrivateRouter /> : <PublicRouter />;
   }

--- a/src/redux/modules/auth.js
+++ b/src/redux/modules/auth.js
@@ -2,6 +2,7 @@
 const LOG_IN = 'LOG_IN';
 const LOG_OUT = 'LOG_OUT';
 const SET_USER = 'SET_USER';
+const SET_PROVIDER = 'SET_PROVIDER';
 
 // Action Creators
 function setLogIn(token) {
@@ -17,20 +18,31 @@ function logout() {
   };
 }
 
+function setProvider(provider) {
+  return {
+    type: SET_PROVIDER,
+    provider
+  };
+}
+
 // API Actions
-function socialLogin(...userInfo) {
+function socialLogin(userInfo, socialProvider) {
   return (dispatch) => {
     console.log(userInfo);
 
     const token = 'Career Talk Token';
 
-    return dispatch(setLogIn(token));
+    dispatch(setProvider(socialProvider));
+    dispatch(setLogIn(token));
+
+    return true;
   };
 }
 
 // Initial State
 const initialState = {
-  isLoggedIn: false
+  isLoggedIn: false,
+  socialProvider: ''
 };
 
 // Reducer
@@ -41,6 +53,8 @@ function reducer(state = initialState, action) {
       return applyLogIn(state, action);
     case LOG_OUT:
       return applyLogOut(state, action);
+    case SET_PROVIDER:
+      return applySetProvider(state, action);
     default:
       return state;
   }
@@ -56,19 +70,26 @@ function applyLogIn(state, action) {
   };
 }
 
-function applyLogOut(state, action) {
-  AsyncStorage.clear();
+function applyLogOut() {
   return {
-    ...state,
     isLoggedIn: false,
     token: ''
+  };
+}
+
+function applySetProvider(state, action) {
+  const { provider } = action;
+  return {
+    ...state,
+    socialProvider: provider
   };
 }
 
 // Exports
 
 const actionCreators = {
-  socialLogin
+  socialLogin,
+  logout
 };
 
 export { actionCreators };

--- a/src/screens/Login/index.js
+++ b/src/screens/Login/index.js
@@ -11,8 +11,8 @@ const mapStateToProps = (state) => {
 };
 
 const mapDispatchToProps = dispatch => ({
-  socialLogin: (info) => {
-    dispatch(authActions.socialLogin(info));
+  socialLogin: (info, socialProvider) => {
+    dispatch(authActions.socialLogin(info, socialProvider));
   }
 });
 

--- a/src/screens/Login/loginContainer.js
+++ b/src/screens/Login/loginContainer.js
@@ -12,17 +12,15 @@ class Container extends React.Component {
     password: '',
   };
 
-  componentWillMount() {
-    this._googleIsSignedIn();
-  }
+  //         FACEBOOK       //
 
-  // Create response callback.
+  // Create facebook signin response callback.
   _responseInfoCallback = (error, result) => {
     if (error) {
       console.error(error.toString());
     } else {
       // send userInfo with token to store
-      this.props.socialLogin(result);
+      this.props.socialLogin(result, 'facebook');
     }
   };
 
@@ -52,14 +50,17 @@ class Container extends React.Component {
     }
   };
 
+  //         GOOGLE       //
+
+  // Google Siginin
   _googleSignIn = async () => {
     try {
       await GoogleSignin.hasPlayServices();
       const userInfo = await GoogleSignin.signIn();
 
       // send userInfo to store
-      this.props.socialLogin(userInfo);
       this.setState({ isGoogleSignedIn: true });
+      this.props.socialLogin(userInfo, 'google');
     } catch (error) {
       if (error.code === statusCodes.SIGN_IN_CANCELLED) {
         // user cancelled the login flow
@@ -73,29 +74,12 @@ class Container extends React.Component {
     }
   };
 
-  _googleIsSignedIn = async () => {
-    const isGoogleSignedIn = await GoogleSignin.isSignedIn();
-    this.setState({ isGoogleSignedIn });
-  };
-
-  _gooogleSignOut = async () => {
-    try {
-      await GoogleSignin.revokeAccess();
-      await GoogleSignin.signOut();
-      this.setState({ isGoogleSignedIn: false });
-      // Remember to remove the user from your app's state as well
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
   render() {
     return (
       <LoginPage
         {...this.state}
         facebookLoginFinished={this._facebookLoginFinished}
         googleSigin={this._googleSignIn}
-        googleSignOut={this._gooogleSignOut}
       />
     );
   }

--- a/src/screens/Login/loginPresenter.js
+++ b/src/screens/Login/loginPresenter.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Actions } from 'react-native-router-flux';
 import { LoginButton } from 'react-native-fbsdk';
 import { GoogleSigninButton } from 'react-native-google-signin';
 import { SafeAreaView, View, Button, StyleSheet, Text, Dimensions, Image } from 'react-native';
@@ -18,16 +17,12 @@ const LoginPage = (props) => {
       </View>
       <View style={styles.content}>
         <View style={{ paddingVertical: 15 }}>
-          {props.isGoogleSignedIn ? (
-            <Button onPress={props.googleSignOut} title="Google Signout" />
-          ) : (
-            <GoogleSigninButton
-              style={{ width: 230, height: 48 }}
-              size={GoogleSigninButton.Size.Wide}
-              color={GoogleSigninButton.Color.Light}
-              onPress={props.googleSigin}
-            />
-          )}
+          <GoogleSigninButton
+            style={{ width: 230, height: 48 }}
+            size={GoogleSigninButton.Size.Wide}
+            color={GoogleSigninButton.Color.Light}
+            onPress={props.googleSigin}
+          />
         </View>
 
         <Text>OR</Text>

--- a/src/screens/Settings/index.js
+++ b/src/screens/Settings/index.js
@@ -1,3 +1,20 @@
+import { connect } from 'react-redux';
+import { actionCreators as authActions } from '../../redux/modules/auth';
 import settings from './settings';
 
-export default settings;
+const mapStateToProps = (state) => {
+  const { auth: { isLoggedIn, socialProvider } } = state;
+
+  return {
+    isLoggedIn,
+    socialProvider,
+  };
+};
+
+const mapDispatchToProps = dispatch => ({
+  logout: () => {
+    dispatch(authActions.logout());
+  }
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(settings);

--- a/src/screens/Settings/settings.js
+++ b/src/screens/Settings/settings.js
@@ -1,13 +1,33 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
-// import { Actions } from 'react-native-router-flux';
+import { SafeAreaView, Text, StyleSheet, Button } from 'react-native';
+import { LoginButton } from 'react-native-fbsdk';
+import { GoogleSignin } from 'react-native-google-signin';
 
 class SettingsPage extends React.Component {
+  _googleSignOut = async () => {
+    try {
+      // Finish Google Session
+      await GoogleSignin.revokeAccess();
+      await GoogleSignin.signOut();
+      // Clear auth state
+      this.props.logout();
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
   render() {
+    const { socialProvider, logout } = this.props;
+
     return (
-      <View style={styles.container}>
+      <SafeAreaView style={styles.container}>
         <Text>Settings Page</Text>
-      </View>
+        {socialProvider && socialProvider === 'facebook' ? (
+          <LoginButton onLogoutFinished={logout} />
+        ) : (
+          <Button onPress={this._googleSignOut} title="Google Logout" />
+        )}
+      </SafeAreaView>
     );
   }
 }


### PR DESCRIPTION
* Users can sign out from settings page
* Based on the social provider, we will show different sign out button => Facebook or Google
* Clicking sign out button will do follow things:
   - Finish the session with the social provider
   - Reset the CareerTalk's `auth` state => `{ isLoggedIn: false, socialProvider: '' }`